### PR TITLE
iteritems() -> items() for quick Python3 fix

### DIFF
--- a/templates/dellos10_snmp.j2
+++ b/templates/dellos10_snmp.j2
@@ -27,7 +27,7 @@ dellos_snmp:
 
 ###############################################}
 {% if dellos_snmp is defined and dellos_snmp %}
-{% for key,value in dellos_snmp.iteritems() %}
+{% for key,value in dellos_snmp.items() %}
   {% if key == "snmp_contact" %}
     {% if value %}
 snmp-server contact {{ value }}

--- a/templates/dellos9_snmp.j2
+++ b/templates/dellos9_snmp.j2
@@ -93,7 +93,7 @@ dellos_snmp:
 {% if dellos_snmp is defined and dellos_snmp %}
 
 {% if dellos_snmp %}
-{% for key,value in dellos_snmp.iteritems() %}
+{% for key,value in dellos_snmp.items() %}
   {% if key == "snmp_contact" %}
     {% if value %}
 snmp-server contact {{ value }}


### PR DESCRIPTION
possible performance hit for large vars files
on Python2 but unlikely to impact most configs